### PR TITLE
feat: add probes for the agent and platform charts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,14 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch $GITHUB_BASE_REF)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
+        env:
+          GITHUB_BASE_REF: $github.base_ref
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --target-branch $GITHUB_BASE_REF
+        env:
+          GITHUB_BASE_REF: $github.base_ref

--- a/charts/steadybit-agent/Chart.yaml
+++ b/charts/steadybit-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: steadybit-agent
 description: steadybit Agent Helm chart for Kubernetes.
-version: 0.3.7
+version: 0.4.0
 appVersion: latest
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-agent/templates/daemonset.yaml
+++ b/charts/steadybit-agent/templates/daemonset.yaml
@@ -56,6 +56,18 @@ spec:
             - containerPort: 5005
               protocol: TCP
           {{ end }}
+          {{- if .Values.agent.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              port: {{ .Values.agent.port }}
+              path: /health
+            initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.agent.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.agent.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.agent.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.agent.livenessProbe.failureThreshold }}
+          {{- end }}
           env:
             - name: STEADYBIT_AGENT_REGISTER_URL
               value: {{ .Values.agent.registerUrl | quote }}
@@ -82,6 +94,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: STEADYBIT_HTTP_ENDPOINT_PORT
+              value: {{ .Values.agent.port | quote }}
 {{- with .Values.agent.env }}
 {{ toYaml . | indent 12 }}
 {{- end }}

--- a/charts/steadybit-agent/values.yaml
+++ b/charts/steadybit-agent/values.yaml
@@ -26,6 +26,8 @@ agent:
   containerRuntimeSocket: null
   # agent.runcRoot -- use this to override the host path for the runc root path to mount. By default it is derived from containerRuntime
   runcRoot: null
+  # agent.port -- configure the port of the agent's HTTP endpoints (expose health and debugging information)
+  port: 42899
   # agent.env -- Additional environment variables for the steadybit agent
   env: []
   # agent.extraLabels -- Additional labels
@@ -36,6 +38,15 @@ agent:
   openshift: false
   # agent.remoteDebug -- Set to true for starting in debug mode and exposing port 5005
   remoteDebug: false
+
+  ## agent.livenessProbe.* -- Configuration of the Kubernetes liveness probe for the agent daemonset
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
 
 cluster:
   # cluster.name Represents the name that will be assigned to this Kubernetes cluster in steadybit

--- a/charts/steadybit-platform/Chart.yaml
+++ b/charts/steadybit-platform/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: steadybit-platform
 description: steadybit Platform Helm chart for Kubernetes.
-version: 0.1.7
+version: 0.2.0
 appVersion: latest
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-platform/templates/deployment-platform.yaml
+++ b/charts/steadybit-platform/templates/deployment-platform.yaml
@@ -36,6 +36,28 @@ spec:
             - name: websocket-port
               containerPort: 7878
               protocol: TCP
+          {{- if .Values.platform.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              port: ui-port
+              path: /api/health
+            initialDelaySeconds: {{ .Values.platform.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.platform.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.platform.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.platform.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.platform.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.platform.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              port: ui-port
+              path: /api/health
+            initialDelaySeconds: {{ .Values.platform.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.platform.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.platform.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.platform.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.platform.startupProbe.failureThreshold }}
+          {{- end }}
           env:
             - name: STEADYBIT_TENANT_AGENTKEY
               value: {{ .Values.agent.key | quote }}

--- a/charts/steadybit-platform/values.yaml
+++ b/charts/steadybit-platform/values.yaml
@@ -32,6 +32,24 @@ platform:
   ## platform.service.type -- Type for the service to use
     type: LoadBalancer
 
+  ## platform.startupProbe.* -- Configuration of the Kubernetes startup probe for the platform deployment
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 100
+    successThreshold: 1
+
+  ## platform.livenessProbe.* -- Configuration of the Kubernetes liveness probe for the platform deployment
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+
   # -- Specific configuration for the database.
   database:
     enabled: true


### PR DESCRIPTION
# Why

The platform & agents currently do not register any health
endpoints with Kubernetes causing broken systems to exist
undetected.

# What

Register (optional) startup and liveness probes. For the
agent we do not offer startup probes out of the box, because
these are only supported in later Kubernetes versions and
we want to reduce the likelyhood of upgrade problems.