### PR TITLE
fix: outpost - inline actions for old helm builds and add podLabels

### DIFF
--- a/charts/steadybit-outpost/templates/_helpers.tpl
+++ b/charts/steadybit-outpost/templates/_helpers.tpl
@@ -222,16 +222,7 @@ environment variables for oauth2 authentication
 - name: STEADYBIT_AGENT_AUTH_OAUTH2_TOKEN_URI
   value: {{ .tokenUri | quote }}
 {{ end -}}
-{{ include
-    "mtlsEnv"
-     (dict
-        "env_prefix" "STEADYBIT_AGENT_AUTH_OAUTH2"
-        "values_prefix" ".Values.outpost.auth.oauth2.tls"
-        "directory" "oauth2"
-        "tls" .tls
-        "secretName" $secretName
-    )
--}}
+{{ include "mtlsEnv" (dict "env_prefix" "STEADYBIT_AGENT_AUTH_OAUTH2" "values_prefix" ".Values.outpost.auth.oauth2.tls" "directory" "oauth2" "tls" .tls "secretName" $secretName) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -240,43 +231,21 @@ environment variables for oauth2 authentication
 volume mounts for extension mTLS certificates
 */}}
 {{- define "oauth2VolumeMounts" -}}
-{{ include
-    "mtlsVolumeMounts"
-     (dict
-        "directory" "oauth2"
-        "tls" .Values.outpost.auth.oauth2.tls
-    )
--}}
+{{ include "mtlsVolumeMounts" (dict "directory" "oauth2" "tls" .Values.outpost.auth.oauth2.tls) -}}
 {{- end -}}
 
 {{/*
 volume mounts for extension mTLS certificates
 */}}
 {{- define "oauth2Volumes" -}}
-{{ include
-    "mtlsVolumes"
-     (dict
-        "directory" "extensions"
-        "tls" .Values.outpost.auth.oauth2.tls
-        "secretName" (include "steadybit-outpost.fullname" . )
-    )
--}}
+{{ include "mtlsVolumes" (dict "directory" "extensions" "tls" .Values.outpost.auth.oauth2.tls "secretName" (include "steadybit-outpost.fullname" . )) -}}
 {{- end -}}
 
 {{/*
 environment variables for extension kit configuration
 */}}
 {{- define "extensionEnv" -}}
-{{ include
-    "mtlsEnv"
-     (dict
-        "env_prefix" "STEADYBIT_AGENT_EXTENSIONS"
-        "values_prefix" ".Values.outpost.extensions.tls"
-        "directory" "extensions"
-        "tls" .Values.outpost.extensions.tls
-        "secretName" (include "steadybit-outpost.fullname" . )
-    )
--}}
+{{ include "mtlsEnv" (dict "env_prefix" "STEADYBIT_AGENT_EXTENSIONS" "values_prefix" ".Values.outpost.extensions.tls" "directory" "extensions" "tls" .Values.outpost.extensions.tls "secretName" (include "steadybit-outpost.fullname" . )) -}}
 {{ if .Values.outpost.extensions.tls.hostnameVerification -}}
 - name: STEADYBIT_AGENT_EXTENSIONS_HOSTNAME_VERIFICATION
   value: {{ .Values.outpost.extensions.tls.hostnameVerification | quote }}
@@ -288,25 +257,12 @@ environment variables for extension kit configuration
 volume mounts for extension mTLS certificates
 */}}
 {{- define "extensionVolumeMounts" -}}
-{{ include
-    "mtlsVolumeMounts"
-     (dict
-        "directory" "extensions"
-        "tls" .Values.outpost.extensions.tls
-    )
--}}
+{{ include "mtlsVolumeMounts" (dict "directory" "extensions" "tls" .Values.outpost.extensions.tls) -}}
 {{- end -}}
 
 {{/*
 volumes for extension mTLS certificates
 */}}
 {{- define "extensionVolumes" -}}
-{{ include
-    "mtlsVolumes"
-     (dict
-        "directory" "extensions"
-        "tls" .Values.outpost.extensions.tls
-        "secretName" (include "steadybit-outpost.fullname" . )
-    )
--}}
+{{ include "mtlsVolumes" (dict "directory" "extensions" "tls" .Values.outpost.extensions.tls "secretName" (include "steadybit-outpost.fullname" . )) -}}
 {{- end -}}

--- a/charts/steadybit-outpost/templates/statefulset.yaml
+++ b/charts/steadybit-outpost/templates/statefulset.yaml
@@ -24,7 +24,10 @@ spec:
         {{- include "steadybit-outpost.commonLabels" . | nindent 8 }}
         {{- range $key, $value := .Values.outpost.extraLabels }}
         {{ $key }}: {{ $value }}
-      {{- end }}
+        {{- end }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         prometheus.io/scrape: "{{ .Values.outpost.prometheus.scrape }}"
         prometheus.io/path: "/prometheus"

--- a/charts/steadybit-outpost/values.yaml
+++ b/charts/steadybit-outpost/values.yaml
@@ -64,7 +64,7 @@ outpost:
   port: 42899
   # outpost.env -- Additional environment variables for the steadybit outpost
   env: []
-  # outpost.extraLabels -- Additional labels
+  # outpost.extraLabels -- Additional labels added to all outpost kubernetes resources.
   extraLabels: {}
   # outpost.leaderElection -- On kubernetes <= 1.11 you we need to use configmaps for the leader election. Valid values: leases, configmaps
   leaderElection: leases
@@ -170,6 +170,9 @@ serviceAccount:
 
 # podAnnotations -- Additional annotations to be added to the outpost pods.
 podAnnotations: {}
+
+# podLabels -- Additional labels to be added to the outpost pods.
+podLabels: {}
 
 # nodeSelector -- Node labels for pod assignment
 nodeSelector: {}


### PR DESCRIPTION
Older versions of Go [do not support multiline action invocations in templates](https://github.com/golang/go/issues/29770). It looks like the version of helm that is packaged with our spinnaker instance predates that fix. This change only refactors template actions in the outpost chart, so there may be other multiline actions elsewhere.

This change also adds support for a podLabels value (analogous to podAnnotations) so that we can set some labels only on the statefulset pods.