### PR TITLE
fix(steadybit-platform): make preStop sleep handler compatible with Kubernetes < 1.29

### DIFF
--- a/charts/steadybit-platform/Chart.yaml
+++ b/charts/steadybit-platform/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: steadybit-platform
 description: steadybit Platform Helm chart for Kubernetes.
-version: 1.3.1
+version: 1.3.2
 appVersion: 2.6.4
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png
 maintainers:
   - email: daniel.reuter@steadybit.com
-    name: reuda # Daniel Reuter
+    name: reuda  # Daniel Reuter
 sources:
   - https://github.com/steadybit/helm-charts
 annotations:

--- a/charts/steadybit-platform/templates/_helpers.tpl
+++ b/charts/steadybit-platform/templates/_helpers.tpl
@@ -140,6 +140,32 @@ false
 {{- end -}}
 
 
+{{/*
+Renders a container `lifecycle` block, converting any `sleep` preStop/postStart
+handler to an `exec` ["sleep", "<seconds>"] handler on Kubernetes < 1.29.
+The native `sleep` lifecycle handler was introduced as alpha in 1.29 and is not
+recognized by older API servers, which drop it and leave an empty handler that
+fails validation ("must specify a handler type").
+Usage: {{ include "steadybit-platform.lifecycle" (dict "lifecycle" .Values.platform.lifecycle "root" .) | nindent 12 }}
+*/}}
+{{- define "steadybit-platform.lifecycle" -}}
+{{- $lifecycle := .lifecycle | default dict -}}
+{{- if not (semverCompare ">=1.29.0-0" .root.Capabilities.KubeVersion.Version) -}}
+{{- $lifecycle = deepCopy $lifecycle -}}
+{{- range $hook := list "preStop" "postStart" -}}
+{{- if hasKey $lifecycle $hook -}}
+{{- $handler := index $lifecycle $hook -}}
+{{- if hasKey $handler "sleep" -}}
+{{- $seconds := default 0 (index $handler "sleep" "seconds") -}}
+{{- $_ := unset $handler "sleep" -}}
+{{- $_ := set $handler "exec" (dict "command" (list "sleep" (printf "%v" $seconds))) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{ $lifecycle | toYaml }}
+{{- end -}}
+
 {{- define "steadybit-platform.postgresql.fullname" -}}
 {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/charts/steadybit-platform/templates/deployment.yaml
+++ b/charts/steadybit-platform/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: {{ include "steadybit-platform.name" . }}
           image: "{{ .Values.image.name }}:{{ template "validContainerImageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          lifecycle: {{ .Values.platform.lifecycle | toYaml | nindent 12 }}
+          lifecycle: {{ include "steadybit-platform.lifecycle" (dict "lifecycle" .Values.platform.lifecycle "root" .) | nindent 12 }}
           resources:
             requests:
               memory: {{ .Values.resources.requests.memory }}
@@ -264,7 +264,7 @@ spec:
         - name: {{ include "steadybit-platform.name" . }}-port-splitter
           image: "{{ .Values.image.name }}-port-splitter:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          lifecycle: {{ .Values.platform.portsplitter.lifecycle | toYaml | nindent 12 }}
+          lifecycle: {{ include "steadybit-platform.lifecycle" (dict "lifecycle" .Values.platform.portsplitter.lifecycle "root" .) | nindent 12 }}
           ports:
             - name: egress-port
               containerPort: 8081

--- a/charts/steadybit-platform/tests/deployment_test.yaml
+++ b/charts/steadybit-platform/tests/deployment_test.yaml
@@ -3,6 +3,12 @@ templates:
 chart:
   appVersion: 0.0.0
   version: 0.0.0
+# Pin a modern Kubernetes version so snapshots reflect the native `sleep`
+# preStop handler. The exec fallback for older clusters (< 1.29) is covered by
+# dedicated tests that override these capabilities.
+capabilities:
+  majorVersion: 1
+  minorVersion: 29
 tests:
   - it: manifest should support Recreate strategy
     asserts:
@@ -134,3 +140,43 @@ tests:
           mode: "SAAS"
     asserts:
       - matchSnapshot: {}
+  - it: should use native sleep preStop handler on Kubernetes >= 1.29
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    set:
+      platform:
+        portSplit:
+          enabled: true
+        ingressOrigin: https://example.ingress.steadybit.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.sleep.seconds
+          value: 20
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.sleep.seconds
+          value: 20
+  - it: should fall back to exec sleep preStop handler on Kubernetes < 1.29
+    capabilities:
+      majorVersion: 1
+      minorVersion: 27
+    set:
+      platform:
+        portSplit:
+          enabled: true
+        ingressOrigin: https://example.ingress.steadybit.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - sleep
+            - "20"
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle.preStop.sleep
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
+          value:
+            - sleep
+            - "20"

--- a/charts/steadybit-platform/values.yaml
+++ b/charts/steadybit-platform/values.yaml
@@ -31,7 +31,7 @@ platform:
   # platform.ingressOrigin -- Should be set to the ingress origin, e.g., https://ingress.steadybit.example.com. Will be used to construct URLs in HTTP responses to agents. This configuration will overwrite the port defined in platform.publicWebsocketPort
   ingressOrigin: null
   # -- Use this to set additional environment variables See https://docs.steadybit.com/install-and-configure/install-on-prem-platform/advanced-configuration
-  envFrom: [ ]
+  envFrom: []
   env:
     - name: STEADYBIT_AUTH_PROVIDER
       value: "static"
@@ -40,11 +40,11 @@ platform:
     - name: STEADYBIT_AUTH_STATIC_0_PASSWORD
       value: "{noop}admin"
   # platform.extraLabels -- Additional labels
-  extraLabels: { }
+  extraLabels: {}
   # platform.extraVolumes -- Additional volumes to which the platform container will be mounted.
-  extraVolumes: [ ]
+  extraVolumes: []
   # platform.extraVolumeMounts -- Additional volumeMounts to which the platform container will be mounted.
-  extraVolumeMounts: [ ]
+  extraVolumeMounts: []
   logging:
     format: text
   service:
@@ -67,7 +67,7 @@ platform:
       useInitContainer: true
   uiImages:
     # platform.uiImages.cspDomains -- Additional domains to add to the Content-Security-Policy header for loading images
-    cspDomains: [ ]
+    cspDomains: []
     navigation:
       # platform.uiImages.navigation.url -- URL to a custom navigation image; takes preference over data
       url: null
@@ -151,8 +151,8 @@ image:
   tag: null
   # image.pullPolicy -- Specifies when to pull the image container.
   pullPolicy: Always
-  registry: { }
-  pullSecrets: [ ]
+  registry: {}
+  pullSecrets: []
 
 serviceAccount:
   # serviceAccount.create -- Specifies whether a ServiceAccount should be created.
@@ -161,17 +161,17 @@ serviceAccount:
   # If not set and `create` is true, a name is generated using the fullname template.
   name: null
   # serviceAccount.annotations.* -- Annotations for the service account
-  annotations: { }
+  annotations: {}
 
 # podAnnotations -- Additional annotations to be added to the platform pod.
-podAnnotations: { }
+podAnnotations: {}
 
 # -- Ingress configuration properties
 ingress:
   # ingress.enabled -- Set to true to create an ingress. Defaults to false on openshift, true otherwise.
   enabled: null
-  annotations: { }
-  hosts: [ ]
+  annotations: {}
+  hosts: []
   # - platform.steadybit.local
 
 # -- HTTPRoute configuration properties for Gateway API
@@ -179,24 +179,24 @@ httpRoute:
   # httpRoute.enabled -- Set to true to create HTTPRoute resources (Gateway API).
   enabled: false
   # httpRoute.annotations -- Annotations applied to both HTTPRoute resources. Can be overridden per route.
-  annotations: { }
+  annotations: {}
   # httpRoute.parentRefs -- Default Gateway references for both HTTPRoute resources. Can be overridden per route. See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference
-  parentRefs: [ ]
+  parentRefs: []
   # - name: my-gateway
   #   namespace: gateway-ns
   # httpRoute.hostnames -- Default hostnames for both HTTPRoute resources. Can be overridden per route. See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname
-  hostnames: [ ]
+  hostnames: []
   # - platform.steadybit.local
   # httpRoute.ws -- Per-route overrides for the WebSocket HTTPRoute (agent traffic). Falls back to shared values above when not set.
   ws:
-    parentRefs: [ ]
-    hostnames: [ ]
-    annotations: { }
+    parentRefs: []
+    hostnames: []
+    annotations: {}
   # httpRoute.ui -- Per-route overrides for the UI HTTPRoute (user traffic). Falls back to shared values above when not set.
   ui:
-    parentRefs: [ ]
-    hostnames: [ ]
-    annotations: { }
+    parentRefs: []
+    hostnames: []
+    annotations: {}
   # httpRoute.httpRedirect -- Creates an HTTPRoute that redirects HTTP to HTTPS (301). Requires a Gateway listener on HTTP.
   # When enabling, use the dedicated-listener pattern: scope ws/ui parentRefs to the HTTPS listener via `sectionName: https`,
   # and scope this redirect to the HTTP listener via `sectionName: http`. Otherwise the ws/ui routes will also bind to the HTTP
@@ -206,12 +206,12 @@ httpRoute:
     # httpRoute.httpRedirect.enabled -- Set to true to create the HTTP-to-HTTPS redirect HTTPRoute.
     enabled: false
     # httpRoute.httpRedirect.parentRefs -- Gateway references for the redirect route. Should target the HTTP listener via sectionName.
-    parentRefs: [ ]
+    parentRefs: []
     # - name: my-gateway
     #   namespace: gateway-ns
     #   sectionName: http
   # httpRoute.targetGroupAttributes -- ALB target group attributes (key/value pairs) applied to the platform service's target groups via TargetGroupConfiguration. Use to configure stickiness, deregistration delay, etc. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes
-  targetGroupAttributes: [ ]
+  targetGroupAttributes: []
   # - key: stickiness.enabled
   #   value: "true"
   # - key: stickiness.type
@@ -225,7 +225,7 @@ httpRoute:
 route:
   # route.enabled -- Set to true to create a route (OpenShift). Defaults to true on openshift, false otherwise.
   enabled: null
-  annotations: { }
+  annotations: {}
   host: null
   subdomain: null
   tls:
@@ -235,20 +235,20 @@ route:
 # -- Service configuration properties
 service:
   type: null
-  annotations: { }
+  annotations: {}
 
 # nodeSelector -- Node labels for pod assignment
-nodeSelector: { }
+nodeSelector: {}
 
 # tolerations -- Tolerations to influence platform pod assignment.
-tolerations: [ ]
+tolerations: []
 
 # topologySpreadConstraints -- Spread constraints to influence platform pod assignment.
 # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
-topologySpreadConstraints: [ ]
+topologySpreadConstraints: []
 
 # affinity -- Affinities to influence platform pod assignment.
-affinity: { }
+affinity: {}
 
 
 resources:

--- a/charts/steadybit-platform/values.yaml
+++ b/charts/steadybit-platform/values.yaml
@@ -128,11 +128,17 @@ platform:
   terminationGracePeriodSeconds: 0  # default is 0, that means no grace period and all experiments are canceled immediately during shutdown.
   ## The interval in seconds to check for experiment executions during shutdown
   experimentExecutionShutdownCheckInterval: 10
+  ## platform.lifecycle -- Container lifecycle hooks for the platform container.
+  ## On Kubernetes < 1.29 the native `sleep` preStop handler is not available and
+  ## is automatically rendered as an `exec` ["sleep", "<seconds>"] handler instead.
   lifecycle:
     preStop:
       sleep:
         seconds: 20
   portsplitter:
+    ## platform.portsplitter.lifecycle -- Container lifecycle hooks for the port-splitter sidecar.
+    ## On Kubernetes < 1.29 the native `sleep` preStop handler is automatically
+    ## rendered as an `exec` ["sleep", "<seconds>"] handler instead.
     lifecycle:
       preStop:
         sleep:


### PR DESCRIPTION
## Problem

A customer on Kubernetes **1.27** got this error installing/upgrading the platform:

```
failed to create resource: Deployment.apps "steadybit-platform" is invalid:
spec.template.spec.containers[0].lifecycle.preStop: Required value: must specify a handler type
```

The chart's default `preStop` hook uses the native **`sleep` lifecycle handler**, which was only introduced in Kubernetes **1.29** (alpha). On older clusters the API server doesn't recognize the `sleep` field, silently drops it, and is left with an empty `preStop: {}` — which then fails validation. Both the platform container and the port-splitter sidecar were affected.

## Fix

Added a `steadybit-platform.lifecycle` helper that renders the lifecycle based on the cluster's Kubernetes version (`semverCompare ">=1.29.0-0" .Capabilities.KubeVersion.Version`):

- **Kubernetes ≥ 1.29** → native `sleep` handler, unchanged.
- **Kubernetes < 1.29** → automatically rewritten to `exec: { command: ["sleep", "<seconds>"] }`, which is valid on every version.

Applied to both `lifecycle:` blocks in `deployment.yaml` (platform container + port-splitter sidecar).

## Tests

- Pinned the deployment test suite to k8s 1.29 so the **13 existing snapshots stay unchanged** (still render native `sleep`).
- Added two explicit tests: native `sleep` on ≥1.29, and `exec ["sleep","20"]` fallback on 1.27 — both asserting the sidecar too.
- Full suite: **51 tests / 41 snapshots pass**, `helm lint` clean.

## Customer workaround (no release needed)

```yaml
platform:
  lifecycle:
    preStop:
      exec:
        command: ["sleep", "20"]
  portsplitter:
    lifecycle:
      preStop:
        exec:
          command: ["sleep", "20"]
```

> Note: `Chart.yaml` version intentionally left untouched — version bumps are handled by the separate automated `chore: update helm chart version` commits.