### PR TITLE
feat(steadybit-agent): allow overriding the auto-registration image individually

### DIFF
--- a/charts/steadybit-agent/Chart.yaml
+++ b/charts/steadybit-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-agent
 description: steadybit agent Helm chart for Kubernetes.
-version: 3.1.105
+version: 3.1.106
 appVersion: 2.3.8
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-agent/templates/_podTemplate.tpl
+++ b/charts/steadybit-agent/templates/_podTemplate.tpl
@@ -37,7 +37,7 @@
         {{- if not .Values.agent.extensions.autoregistration.useLegacyAutoregistration }}
         {{- $globalImage := dig "image" dict (.Values.global | default dict) }}
         - name: "steadybit-agent-kubernetes-autoregistration"
-          image: "{{ .Values.agent.extensions.autoregistration.image.registry | default (dig "registry" "ghcr.io" $globalImage) }}/{{ .Values.agent.extensions.autoregistration.image.name }}:{{ .Values.agent.extensions.autoregistration.image.tag }}"
+          image: "{{ include "extensionlib.image" (dict "Values" (dict "image" .Values.agent.extensions.autoregistration.image "global" .Values.global) "Chart" .Chart) }}"
           imagePullPolicy: {{ .Values.agent.extensions.autoregistration.image.pullPolicy | default (dig "pullPolicy" "Always" $globalImage) }}
           resources:
             requests:

--- a/charts/steadybit-agent/tests/statefulset_test.yaml
+++ b/charts/steadybit-agent/tests/statefulset_test.yaml
@@ -270,6 +270,56 @@ tests:
     asserts:
       - matchSnapshot: { }
 
+  - it: should override the autoregistration image individually with a full registry-prefixed name
+    set:
+      global:
+        clusterName: test
+      agent:
+        key: abcdefg
+        extensions:
+          autoregistration:
+            image:
+              name: my.registry.local/steadybit/extension-auto-registration-kubernetes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my.registry.local/steadybit/extension-auto-registration-kubernetes:v0.0.0
+        template: statefulset.yaml
+
+  - it: should apply a per-image registry override to the autoregistration image
+    set:
+      global:
+        clusterName: test
+      agent:
+        key: abcdefg
+        extensions:
+          autoregistration:
+            image:
+              registry: my.registry.local
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my.registry.local/steadybit/extension-auto-registration-kubernetes:v0.0.0
+        template: statefulset.yaml
+
+  - it: should apply the global registry to the autoregistration image
+    set:
+      global:
+        clusterName: test
+        image:
+          registry: my.registry.local
+      agent:
+        key: abcdefg
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my.registry.local/steadybit/extension-auto-registration-kubernetes:v0.0.0
+        template: statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: my.registry.local/steadybit/agent:0.0.0
+        template: statefulset.yaml
+
   - it: should fail if deprecated priorityClassName.use is used
     set:
       priorityClassName:

--- a/charts/steadybit-agent/values.yaml
+++ b/charts/steadybit-agent/values.yaml
@@ -180,9 +180,9 @@ agent:
       # agent.extensions.autoregistration.useLegacyAutoregistration -- DEPRECATED: use the internal autoregistration mechanism of the steadybit agent instead of the extension-auto-registration-kubernetes sidecar.
       useLegacyAutoregistration: false
       image:
-        # agent.extensions.autoregistration.image.registry -- The container registry to use of the steadybit extension-auto-registration-kubernetes.
-        registry: ghcr.io
-        # agent.extensions.autoregistration.image.name -- The container image to use of the steadybit extension-auto-registration-kubernetes.
+        # agent.extensions.autoregistration.image.registry -- The container registry to use of the steadybit extension-auto-registration-kubernetes. Defaults to global.image.registry or ghcr.io.
+        registry: null
+        # agent.extensions.autoregistration.image.name -- The container image to use of the steadybit extension-auto-registration-kubernetes. May contain a registry prefix (e.g. "my.registry.local/steadybit/extension-auto-registration-kubernetes"), in which case image.registry is ignored.
         name: steadybit/extension-auto-registration-kubernetes
         # agent.extensions.autoregistration.image.tag -- tag name of the extension-auto-registration-kubernetes image to use.
         tag: v1.0.5


### PR DESCRIPTION
## Problem

Every image in the agent chart can be overridden individually **except the auto-registration container**. Its image reference was hand-rolled in `_podTemplate.tpl` and **always** prepended a registry:

```
image: "{{ .Values...autoregistration.image.registry | default (... "ghcr.io" ...) }}/{{ ...image.name }}:{{ ...image.tag }}"
```

Two consequences for air-gapped / mirrored-registry installs:

1. Setting a **full image name** (e.g. `my.registry.local/steadybit/extension-auto-registration-kubernetes`) produced a broken `ghcr.io/my.registry.local/...`.
2. A `global.image.registry` override **never reached** auto-registration, because its `image.registry` defaulted to a hard-coded `ghcr.io` instead of `null`.

So this one image was locked to the global-registry-prefix model while the agent and all extension images already support individual overrides via `extensionlib.image`.

## Fix

- Render the auto-registration image through the shared **`extensionlib.image`** helper (passing a sub-context whose `.Values.image` is the auto-registration image block). This brings it in line with the agent and extension images:
  - a registry-prefixed `image.name` is used **as-is** (registry not prepended),
  - `image.registry` overrides per image,
  - `global.image.registry` (→ `ghcr.io`) is the fallback.
- Changed the auto-registration `image.registry` default from `ghcr.io` to `null` so it follows the global registry, consistent with the agent image.

**Default rendered output is unchanged** (`ghcr.io/steadybit/extension-auto-registration-kubernetes:<tag>`) — all 86 existing snapshots pass untouched.

## Tests

Added three behavior tests to `statefulset_test.yaml`:
- full registry-prefixed `image.name` is used verbatim,
- per-image `image.registry` override is applied,
- `global.image.registry` now reaches both the auto-registration **and** agent images.

Full agent chart suite: **65 tests / 86 snapshots pass**, `helm lint` clean.

> Note: `Chart.yaml` version left untouched — handled by the automated version-bump commits. The platform port-splitter image was intentionally left out of scope.