### PR TITLE
feat(steadybit-agent): add opt-in oom_score_adj protection for the agent

### DIFF
--- a/charts/steadybit-agent/Chart.yaml
+++ b/charts/steadybit-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-agent
 description: steadybit agent Helm chart for Kubernetes.
-version: 3.1.125
+version: 3.1.125-devel
 appVersion: 2.3.10
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-agent/Chart.yaml
+++ b/charts/steadybit-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-agent
 description: steadybit agent Helm chart for Kubernetes.
-version: 3.1.124
+version: 3.1.125
 appVersion: 2.3.10
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-agent/README.md
+++ b/charts/steadybit-agent/README.md
@@ -94,6 +94,26 @@ agent:
       insecureSkipVerify: true
 ```
 
+### Protecting the agent from the OOM killer
+
+On memory pressure the Linux OOM killer may terminate the agent. To have it picked last, you can lower the
+agent container's `oom_score_adj`:
+
+```yaml
+agent:
+  oomScoreAdj:
+    enabled: true
+    value: -997 # -1000..1000; -997 matches the value Kubernetes assigns to Guaranteed QoS pods
+```
+
+The agent container stays non-root, but enabling this adds `CAP_SYS_RESOURCE` and
+`allowPrivilegeEscalation: true` to it (and, on OpenShift, to the generated SecurityContextConstraint). The
+namespace therefore cannot run under the `baseline`/`restricted` Pod Security Standard. If the capability is
+not granted at runtime the agent still starts and logs a warning.
+
+A cheaper alternative that needs no extra privileges is to raise `resources.requests.memory`, which already
+lowers the score the kubelet assigns to Burstable pods.
+
 ### Configuring Additional Volumes
 
 You may want to have additional volumes to be mounted to the agent container, e.g. for SSL certificates.

--- a/charts/steadybit-agent/README.md
+++ b/charts/steadybit-agent/README.md
@@ -96,8 +96,8 @@ agent:
 
 ### Protecting the agent from the OOM killer
 
-On memory pressure the Linux OOM killer may terminate the agent. To have it picked last, you can lower the
-agent container's `oom_score_adj`:
+On memory pressure the Linux OOM killer may terminate the agent. To have it picked last, the agent container's
+`oom_score_adj` is lowered to `-997` by default:
 
 ```yaml
 agent:
@@ -106,10 +106,20 @@ agent:
     value: -997 # -1000..1000; -997 matches the value Kubernetes assigns to Guaranteed QoS pods
 ```
 
-The agent container stays non-root, but enabling this adds `CAP_SYS_RESOURCE` and
-`allowPrivilegeEscalation: true` to it (and, on OpenShift, to the generated SecurityContextConstraint). The
-namespace therefore cannot run under the `baseline`/`restricted` Pod Security Standard. If the capability is
-not granted at runtime the agent still starts and logs a warning.
+The agent container stays non-root, but this adds `CAP_SYS_RESOURCE` and `allowPrivilegeEscalation: true` to it
+(and, on OpenShift, to the generated SecurityContextConstraint). If the capability is not granted at runtime the
+agent still starts and logs a warning.
+
+> **:warning:** Because it adds a capability and allows privilege escalation, the agent namespace **cannot** run
+> under the `baseline` or `restricted` [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+> while this is enabled. If your cluster enforces one of those, either run the agent in a `privileged`-level
+> namespace or disable this feature:
+
+```yaml
+agent:
+  oomScoreAdj:
+    enabled: false
+```
 
 A cheaper alternative that needs no extra privileges is to raise `resources.requests.memory`, which already
 lowers the score the kubelet assigns to Burstable pods.

--- a/charts/steadybit-agent/templates/_podTemplate.tpl
+++ b/charts/steadybit-agent/templates/_podTemplate.tpl
@@ -240,12 +240,25 @@
             - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
               value: "true"
             {{ end -}}
+            {{- if .Values.agent.oomScoreAdj.enabled }}
+            - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+              value: {{ .Values.agent.oomScoreAdj.value | quote }}
+            {{- end }}
             {{- with .Values.agent.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           securityContext:
+            {{- if .Values.agent.oomScoreAdj.enabled }}
+            {{- $sc := deepCopy (.Values.containerSecurityContext | default dict) }}
+            {{- $_ := set $sc "allowPrivilegeEscalation" true }}
+            {{- $caps := deepCopy (get $sc "capabilities" | default dict) }}
+            {{- $_ := set $caps "add" (append (get $caps "add" | default list) "SYS_RESOURCE" | uniq) }}
+            {{- $_ := set $sc "capabilities" $caps }}
+            {{- toYaml $sc | nindent 12 }}
+            {{- else }}
             {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- end }}
           volumeMounts:
             {{- if or (eq .Values.agent.persistence.provider "filesystem") (eq .Values.agent.persistence.provider "hostPath")}}

--- a/charts/steadybit-agent/templates/scc.yaml
+++ b/charts/steadybit-agent/templates/scc.yaml
@@ -9,4 +9,11 @@ runAsUser:
   uid: 10000
 seLinuxContext:
   type: MustRunAs
+{{- if .Values.agent.oomScoreAdj.enabled }}
+allowPrivilegeEscalation: true
+allowedCapabilities:
+  - SYS_RESOURCE
+requiredDropCapabilities:
+  - ALL
+{{- end }}
 {{- end -}}

--- a/charts/steadybit-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -116,6 +116,8 @@ manifest should match snapshot:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -136,8 +138,10 @@ manifest should match snapshot:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -293,6 +297,8 @@ should add aws account id from values:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -313,8 +319,10 @@ should add aws account id from values:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -458,6 +466,8 @@ should add extra volumes and mount:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -478,8 +488,10 @@ should add extra volumes and mount:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -639,6 +651,8 @@ should add match labels:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -659,8 +673,10 @@ should add match labels:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -824,6 +840,8 @@ should add proxy configuration:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -844,8 +862,10 @@ should add proxy configuration:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1000,6 +1020,8 @@ should apply extra pod labels:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1020,8 +1042,10 @@ should apply extra pod labels:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1173,6 +1197,8 @@ should render redis settings:
                   value: "true"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1193,8 +1219,10 @@ should render redis settings:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1347,6 +1375,8 @@ should set priorityClassName from global:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1367,8 +1397,10 @@ should set priorityClassName from global:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1523,6 +1555,8 @@ should set priorityClassName from simple string:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1543,8 +1577,10 @@ should set priorityClassName from simple string:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1683,6 +1719,8 @@ should use deployment with hostPath provider:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1703,8 +1741,10 @@ should use deployment with hostPath provider:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1831,6 +1871,8 @@ should use old internal extension autoregistration:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1851,8 +1893,10 @@ should use old internal extension autoregistration:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2021,6 +2065,8 @@ using extensions with mtls from containerpath:
                   value: /etc/ssl/extra-certs
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2041,8 +2087,10 @@ using extensions with mtls from containerpath:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2208,6 +2256,8 @@ using extensions with mtls from secrets:
                   value: /opt/steadybit/agent/etc/extensions/server/tls.crt
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2228,8 +2278,10 @@ using extensions with mtls from secrets:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2390,6 +2442,8 @@ using image pull secrets with debug json log:
                   value: "6379"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2410,8 +2464,10 @@ using image pull secrets with debug json log:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true

--- a/charts/steadybit-agent/tests/__snapshot__/scc_test.yaml.snap
+++ b/charts/steadybit-agent/tests/__snapshot__/scc_test.yaml.snap
@@ -28,11 +28,16 @@ forced rendering on kubernetes:
         name: steadybit-agent
         namespace: NAMESPACE
   3: |
+    allowPrivilegeEscalation: true
+    allowedCapabilities:
+      - SYS_RESOURCE
     apiVersion: security.openshift.io/v1
     kind: SecurityContextConstraints
     metadata:
       name: my-scc
     priority: null
+    requiredDropCapabilities:
+      - ALL
     runAsUser:
       type: MustRunAs
       uid: 10000
@@ -68,11 +73,16 @@ rendering by default on openshift:
         name: steadybit-agent
         namespace: NAMESPACE
   3: |
+    allowPrivilegeEscalation: true
+    allowedCapabilities:
+      - SYS_RESOURCE
     apiVersion: security.openshift.io/v1
     kind: SecurityContextConstraints
     metadata:
       name: steadybit-agent
     priority: null
+    requiredDropCapabilities:
+      - ALL
     runAsUser:
       type: MustRunAs
       uid: 10000

--- a/charts/steadybit-agent/tests/__snapshot__/statefulset_auth_test.yaml.snap
+++ b/charts/steadybit-agent/tests/__snapshot__/statefulset_auth_test.yaml.snap
@@ -118,6 +118,8 @@ using oauth2 with mtls from containerPath and token uri:
                   value: /etc/ssl/certs/server.crt
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -138,8 +140,10 @@ using oauth2 with mtls from containerPath and token uri:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -298,6 +302,8 @@ using oauth2 with mtls from secrets:
                   value: /opt/steadybit/agent/etc/oauth2/server/tls.crt
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -318,8 +324,10 @@ using oauth2 with mtls from secrets:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true

--- a/charts/steadybit-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/steadybit-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -128,6 +128,8 @@ manifest should match snapshot:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -148,8 +150,10 @@ manifest should match snapshot:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -310,6 +314,8 @@ manifest should use existing secret for agent key:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -330,8 +336,10 @@ manifest should use existing secret for agent key:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -495,6 +503,8 @@ should add aws account id from values:
                   value: "123456789012"
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -515,8 +525,10 @@ should add aws account id from values:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -667,6 +679,8 @@ should add extra volumes and mount:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -687,8 +701,10 @@ should add extra volumes and mount:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -857,6 +873,8 @@ should add match labels:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -877,8 +895,10 @@ should add match labels:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1050,6 +1070,8 @@ should add proxy configuration:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1070,8 +1092,10 @@ should add proxy configuration:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1234,6 +1258,8 @@ should apply extra pod labels:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1254,8 +1280,10 @@ should apply extra pod labels:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1406,6 +1434,8 @@ should not render fsgroup/seccompProfile on openbshift:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1426,8 +1456,10 @@ should not render fsgroup/seccompProfile on openbshift:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1576,6 +1608,8 @@ should not render image registry:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1596,8 +1630,10 @@ should not render image registry:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1759,6 +1795,8 @@ should not render resource limits if set to null:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1776,8 +1814,10 @@ should not render resource limits if set to null:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -1941,6 +1981,8 @@ should set agent port:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -1961,8 +2003,10 @@ should set agent port:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2124,6 +2168,8 @@ should set priorityClassName from global:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2144,8 +2190,10 @@ should set priorityClassName from global:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2308,6 +2356,8 @@ should set priorityClassName from simple string:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2328,8 +2378,10 @@ should set priorityClassName from simple string:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2488,6 +2540,8 @@ should use extension kubernetes autoregistration with all namespaces:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2508,8 +2562,10 @@ should use extension kubernetes autoregistration with all namespaces:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2655,6 +2711,8 @@ should use old kubernetes autoregistration:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2675,8 +2733,10 @@ should use old kubernetes autoregistration:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -2802,6 +2862,8 @@ should use old kubernetes autoregistration with all namespaces:
                       fieldPath: spec.nodeName
                 - name: STEADYBIT_AGENT_WORKING_DIR
                   value: /tmp/steadybit-agent
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -2822,8 +2884,10 @@ should use old kubernetes autoregistration with all namespaces:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -3001,6 +3065,8 @@ using extensions with mtls from containerpath:
                   value: /etc/ssl/extra-certs
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -3021,8 +3087,10 @@ using extensions with mtls from containerpath:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -3195,6 +3263,8 @@ using extensions with mtls from secrets:
                   value: /opt/steadybit/agent/etc/extensions/server/tls.crt
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -3215,8 +3285,10 @@ using extensions with mtls from secrets:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
@@ -3384,6 +3456,8 @@ using image pull secrets with debug json log:
                   value: /tmp/steadybit-agent
                 - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
                   value: "true"
+                - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+                  value: "-997"
               image: ghcr.io/steadybit/agent:0.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -3404,8 +3478,10 @@ using image pull secrets with debug json log:
                   cpu: 500m
                   memory: 250Mi
               securityContext:
-                allowPrivilegeEscalation: false
+                allowPrivilegeEscalation: true
                 capabilities:
+                  add:
+                    - SYS_RESOURCE
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true

--- a/charts/steadybit-agent/tests/deployment_test.yaml
+++ b/charts/steadybit-agent/tests/deployment_test.yaml
@@ -310,7 +310,7 @@ tests:
             host: 127.0.0.1
     asserts:
       - matchSnapshot: { }
-  - it: should not grant oom_score_adj privileges by default
+  - it: should not grant oom_score_adj privileges when disabled
     set:
       agent:
         identifier: abcdefg
@@ -319,6 +319,8 @@ tests:
           provider: redis
           redis:
             host: 127.0.0.1
+        oomScoreAdj:
+          enabled: false
     asserts:
       - template: deployment.yaml
         notExists:

--- a/charts/steadybit-agent/tests/deployment_test.yaml
+++ b/charts/steadybit-agent/tests/deployment_test.yaml
@@ -310,3 +310,85 @@ tests:
             host: 127.0.0.1
     asserts:
       - matchSnapshot: { }
+  - it: should not grant oom_score_adj privileges by default
+    set:
+      agent:
+        identifier: abcdefg
+        key: abcdefg
+        persistence:
+          provider: redis
+          redis:
+            host: 127.0.0.1
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[1].env[?(@.name=="STEADYBIT_AGENT_OOM_SCORE_ADJ")]
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities
+          value:
+            drop:
+              - ALL
+
+  - it: should grant oom_score_adj privileges to the agent container only when enabled
+    set:
+      agent:
+        identifier: abcdefg
+        key: abcdefg
+        persistence:
+          provider: redis
+          redis:
+            host: 127.0.0.1
+        oomScoreAdj:
+          enabled: true
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+            value: "-997"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: true
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[1].securityContext.capabilities.add
+          content: SYS_RESOURCE
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop
+          content: ALL
+      # the autoregistration sidecar must stay unprivileged
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+
+  - it: should honor a custom oom_score_adj value
+    set:
+      agent:
+        identifier: abcdefg
+        key: abcdefg
+        persistence:
+          provider: redis
+          redis:
+            host: 127.0.0.1
+        oomScoreAdj:
+          enabled: true
+          value: -500
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+            value: "-500"

--- a/charts/steadybit-agent/tests/scc_test.yaml
+++ b/charts/steadybit-agent/tests/scc_test.yaml
@@ -56,10 +56,14 @@ tests:
         contains:
           path: requiredDropCapabilities
           content: ALL
-  - it: does not grant SYS_RESOURCE by default on openshift
+  - it: does not grant SYS_RESOURCE when disabled on openshift
     capabilities:
       apiVersions:
         - "security.openshift.io/v1/SecurityContextConstraints"
+    set:
+      agent:
+        oomScoreAdj:
+          enabled: false
     asserts:
       - template: scc.yaml
         notExists:

--- a/charts/steadybit-agent/tests/scc_test.yaml
+++ b/charts/steadybit-agent/tests/scc_test.yaml
@@ -35,3 +35,32 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: grants SYS_RESOURCE when oomScoreAdj is enabled on openshift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1/SecurityContextConstraints"
+    set:
+      agent:
+        oomScoreAdj:
+          enabled: true
+    asserts:
+      - template: scc.yaml
+        equal:
+          path: allowPrivilegeEscalation
+          value: true
+      - template: scc.yaml
+        contains:
+          path: allowedCapabilities
+          content: SYS_RESOURCE
+      - template: scc.yaml
+        contains:
+          path: requiredDropCapabilities
+          content: ALL
+  - it: does not grant SYS_RESOURCE by default on openshift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1/SecurityContextConstraints"
+    asserts:
+      - template: scc.yaml
+        notExists:
+          path: allowedCapabilities

--- a/charts/steadybit-agent/values.yaml
+++ b/charts/steadybit-agent/values.yaml
@@ -92,9 +92,11 @@ agent:
     # agent.oomScoreAdj.enabled -- Lower the agent container's oom_score_adj so the kernel OOM
     # killer terminates it last. This adds CAP_SYS_RESOURCE and allowPrivilegeEscalation=true to
     # the agent container (and to the SecurityContextConstraint on OpenShift); the container stays
-    # non-root. Disabled by default. A cheaper alternative without extra privileges is to raise
-    # resources.requests.memory, which already lowers the score for Burstable pods.
-    enabled: false
+    # non-root. Enabled by default. NOTE: because it adds a capability and allows privilege
+    # escalation, the agent namespace cannot run under the `baseline`/`restricted` Pod Security
+    # Standard while this is on - disable it there. A cheaper alternative without extra privileges
+    # is to raise resources.requests.memory, which already lowers the score for Burstable pods.
+    enabled: true
     # agent.oomScoreAdj.value -- The oom_score_adj value to apply (-1000..1000). -997 matches the
     # value Kubernetes assigns to Guaranteed QoS pods.
     value: -997

--- a/charts/steadybit-agent/values.yaml
+++ b/charts/steadybit-agent/values.yaml
@@ -88,6 +88,16 @@ agent:
   port: 42899
   # agent.env -- Additional environment variables for the steadybit agent
   env: []
+  oomScoreAdj:
+    # agent.oomScoreAdj.enabled -- Lower the agent container's oom_score_adj so the kernel OOM
+    # killer terminates it last. This adds CAP_SYS_RESOURCE and allowPrivilegeEscalation=true to
+    # the agent container (and to the SecurityContextConstraint on OpenShift); the container stays
+    # non-root. Disabled by default. A cheaper alternative without extra privileges is to raise
+    # resources.requests.memory, which already lowers the score for Burstable pods.
+    enabled: false
+    # agent.oomScoreAdj.value -- The oom_score_adj value to apply (-1000..1000). -997 matches the
+    # value Kubernetes assigns to Guaranteed QoS pods.
+    value: -997
   # agent.extraLabels -- Additional labels added to all agent kubernetes resources.
   extraLabels: {}
   # agent.livenessProbe.* -- Configuration of the Kubernetes liveness probe for the agent daemonset


### PR DESCRIPTION
## What

Adds `agent.oomScoreAdj.{enabled,value}` so the agent can be de-prioritized for the kernel OOM killer **without** Guaranteed QoS.

When enabled:
- the **agent** container (not the autoregistration sidecar) gains `capabilities.add: [SYS_RESOURCE]` and `allowPrivilegeEscalation: true`, while keeping `runAsNonRoot`, `runAsUser: 10000`, `readOnlyRootFilesystem` and `drop: [ALL]`;
- `STEADYBIT_AGENT_OOM_SCORE_ADJ` is injected (default `-997`);
- on OpenShift, the generated SecurityContextConstraint permits the capability.

Disabled by default, so existing deployments render unchanged. Requires the companion agent-image change (steadybit/agent#516) which ships `choom` with a `cap_sys_resource` file capability.

## Notes

- `SYS_RESOURCE` forces the namespace off the `baseline`/`restricted` Pod Security Standard.
- README documents the option and the cheaper no-privilege alternative (raising `resources.requests.memory`).

## Testing

- `helm unittest`: 72 tests / 86 snapshots pass, including new deployment/scc cases asserting the cap/env are present only when enabled and the sidecar stays unprivileged.
- Deployed to minikube against a locally built agent image: `/proc/1/oom_score_adj` = `-997`, pod still Burstable, non-root retained.

closes 20324