### PR TITLE
feat(steadybit-platform): per-route target group stickiness for the agent WS route

### DIFF
--- a/charts/steadybit-platform/Chart.yaml
+++ b/charts/steadybit-platform/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: steadybit-platform
 description: steadybit Platform Helm chart for Kubernetes.
-version: 1.3.7
+version: 1.4.0
 appVersion: 2.8.0
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png
 maintainers:
   - email: daniel.reuter@steadybit.com
-    name: reuda # Daniel Reuter
+    name: reuda  # Daniel Reuter
 sources:
   - https://github.com/steadybit/helm-charts
 annotations:

--- a/charts/steadybit-platform/templates/targetgroupconfiguration.yaml
+++ b/charts/steadybit-platform/templates/targetgroupconfiguration.yaml
@@ -21,4 +21,14 @@ spec:
     targetGroupAttributes:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- with .Values.httpRoute.ws.targetGroupAttributes }}
+  routeConfigurations:
+    - routeIdentifier:
+        kind: HTTPRoute
+        namespace: {{ $.Release.Namespace }}
+        name: {{ $fullName }}-ws
+      targetGroupProps:
+        targetGroupAttributes:
+          {{- toYaml . | nindent 10 }}
+  {{- end }}
 {{- end -}}

--- a/charts/steadybit-platform/tests/targetgroupconfiguration_test.yaml
+++ b/charts/steadybit-platform/tests/targetgroupconfiguration_test.yaml
@@ -1,0 +1,65 @@
+templates:
+  - targetgroupconfiguration.yaml
+chart:
+  appVersion: 0.0.0
+  version: 0.0.0
+tests:
+  - it: should not create a TargetGroupConfiguration by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should set only defaultConfiguration when no ws override is given
+    set:
+      httpRoute:
+        enabled: true
+        targetGroupAttributes:
+          - key: stickiness.type
+            value: app_cookie
+          - key: stickiness.app_cookie.cookie_name
+            value: SESSION
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.defaultConfiguration.targetGroupAttributes[0].value
+          value: app_cookie
+      - notExists:
+          path: spec.routeConfigurations
+  - it: should add a per-route lb_cookie override for the ws route, leaving the default untouched
+    set:
+      httpRoute:
+        enabled: true
+        targetGroupAttributes:
+          - key: stickiness.type
+            value: app_cookie
+          - key: stickiness.app_cookie.cookie_name
+            value: SESSION
+        ws:
+          targetGroupAttributes:
+            - key: stickiness.enabled
+              value: "true"
+            - key: stickiness.type
+              value: lb_cookie
+            - key: stickiness.lb_cookie.duration_seconds
+              value: "3600"
+    asserts:
+      # UI/default stickiness stays app_cookie, and the default health check still applies to every target group
+      - equal:
+          path: spec.defaultConfiguration.targetGroupAttributes[0].value
+          value: app_cookie
+      - equal:
+          path: spec.defaultConfiguration.healthCheckConfig.healthCheckPath
+          value: /api/health/liveness
+      # exactly one per-route override, targeting the -ws HTTPRoute with lb_cookie
+      - lengthEqual:
+          path: spec.routeConfigurations
+          count: 1
+      - equal:
+          path: spec.routeConfigurations[0].routeIdentifier.kind
+          value: HTTPRoute
+      - matchRegex:
+          path: spec.routeConfigurations[0].routeIdentifier.name
+          pattern: -ws$
+      - equal:
+          path: spec.routeConfigurations[0].targetGroupProps.targetGroupAttributes[1].value
+          value: lb_cookie

--- a/charts/steadybit-platform/values.yaml
+++ b/charts/steadybit-platform/values.yaml
@@ -198,6 +198,19 @@ httpRoute:
     parentRefs: []
     hostnames: []
     annotations: {}
+    # httpRoute.ws.targetGroupAttributes -- ALB target group attributes for the WebSocket (agent) route's target group,
+    # emitted as a per-route routeConfigurations entry on the TargetGroupConfiguration and merged over
+    # httpRoute.targetGroupAttributes (keys set here win; other default keys still apply). Use this to give the agent
+    # channel duration-based (lb_cookie) stickiness independently of the UI: the agent channel never sets a SESSION
+    # cookie, so the shared app_cookie stickiness is inert for it, and RSocket session resume needs reconnects to land
+    # on the same pod.
+    targetGroupAttributes: []
+    # - key: stickiness.enabled
+    #   value: "true"
+    # - key: stickiness.type
+    #   value: lb_cookie
+    # - key: stickiness.lb_cookie.duration_seconds
+    #   value: "3600"
   # httpRoute.ui -- Per-route overrides for the UI HTTPRoute (user traffic). Falls back to shared values above when not set.
   ui:
     parentRefs: []


### PR DESCRIPTION
Adds `httpRoute.ws.targetGroupAttributes`, rendered as a per-route `routeConfigurations` entry on the `TargetGroupConfiguration` for the `-ws` route (merged over the shared `defaultConfiguration`).

## Why
Part of RSocket experiment-channel **session resume** (agent PR steadybit/agent#528, platform PR steadybit/platform#1701, ticket 21488). For resume, a reconnect must land on the **same platform pod**. The agent WebSocket channel is fronted by the ALB, but — verified on dev-platform — the shared `app_cookie` stickiness (keyed on `SESSION`) is **inert for the agent channel**: agent endpoints (incl. the WS `101` upgrade) never set a `SESSION` cookie, so the ALB returns `AWSALBAPP-*=_remove_` and establishes no affinity. The UI channel does set `SESSION`, and uses a separate route/target group, so it is unaffected.

This lets an operator set duration-based `lb_cookie` stickiness on **only** the agent target group (ALB then issues `AWSALB` unconditionally), which the agent replays on the resume reconnect.

## Changes
- `httpRoute.ws.targetGroupAttributes` value (default `[]` → no change).
- `templates/targetgroupconfiguration.yaml`: emit `routeConfigurations` for the `-ws` route when set.
- Unit test `tests/targetgroupconfiguration_test.yaml` (default absent / override present).
- Chart version 1.3.6 → 1.3.7.

Backward compatible: with the default empty value no `routeConfigurations` is emitted (existing 54 unit tests + 41 snapshots still pass).