### PR TITLE
feat(steadybit-agent): auto-disable oomScoreAdj on GKE Autopilot

### DIFF
--- a/charts/steadybit-agent/Chart.yaml
+++ b/charts/steadybit-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-agent
 description: steadybit agent Helm chart for Kubernetes.
-version: 3.1.139
+version: 3.1.140
 appVersion: 2.4.1
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-agent/README.md
+++ b/charts/steadybit-agent/README.md
@@ -108,7 +108,17 @@ agent:
 
 On **GKE Autopilot** the feature is disabled automatically (detected via the `auto.gke.io` API group):
 Autopilot's admission webhook rejects workloads requesting `CAP_SYS_RESOURCE`, and no workload allowlist is
-published for the agent. Set `enabled: true` to force it on, e.g. if your cluster grants an allowlist exemption.
+published for the agent. When this happens the install/upgrade notes print a notice. Set `enabled: true` to
+force it on, e.g. if your cluster grants an allowlist exemption for the agent.
+
+> **:warning:** Auto-detection relies on Helm's cluster capabilities, so it only works when Helm talks to the
+> cluster (`helm install`/`helm upgrade`, or GitOps tools that pass the cluster's API versions to the template
+> step, as Argo CD does). A bare offline `helm template` renders the non-Autopilot default and Autopilot will
+> reject the manifests — pass `--api-versions auto.gke.io/v1` or set `agent.oomScoreAdj.enabled: false`
+> explicitly in such pipelines.
+
+`enabled` must be `null` or an unquoted boolean — quoted strings like `"false"` (e.g. from `--set-string`)
+are rejected at render time instead of being silently treated as truthy.
 
 The agent container stays non-root, but this adds `CAP_SYS_RESOURCE` and `allowPrivilegeEscalation: true` to it
 (and, on OpenShift, to the generated SecurityContextConstraint). If the capability is not granted at runtime the

--- a/charts/steadybit-agent/README.md
+++ b/charts/steadybit-agent/README.md
@@ -102,9 +102,13 @@ On memory pressure the Linux OOM killer may terminate the agent. To have it pick
 ```yaml
 agent:
   oomScoreAdj:
-    enabled: true
+    enabled: null # null = auto: enabled everywhere except GKE Autopilot; set true/false to override
     value: -997 # -1000..1000; -997 matches the value Kubernetes assigns to Guaranteed QoS pods
 ```
+
+On **GKE Autopilot** the feature is disabled automatically (detected via the `auto.gke.io` API group):
+Autopilot's admission webhook rejects workloads requesting `CAP_SYS_RESOURCE`, and no workload allowlist is
+published for the agent. Set `enabled: true` to force it on, e.g. if your cluster grants an allowlist exemption.
 
 The agent container stays non-root, but this adds `CAP_SYS_RESOURCE` and `allowPrivilegeEscalation: true` to it
 (and, on OpenShift, to the generated SecurityContextConstraint). If the capability is not granted at runtime the

--- a/charts/steadybit-agent/templates/NOTES.txt
+++ b/charts/steadybit-agent/templates/NOTES.txt
@@ -76,3 +76,9 @@ You can get the logs for all of the agents with `kubectl logs`:
 #### WARNING: Consider defining resource limits to prevent potential resource exhaustion. (.Values.resources.limits.memory / .Values.resources.limits.cpu)
 
 {{- end }}
+
+{{- if and (kindIs "invalid" .Values.agent.oomScoreAdj.enabled) (include "steadybit-agent.isGkeAutopilot" .) }}
+
+#### NOTICE: GKE Autopilot detected (auto.gke.io API group) - the oom_score_adj protection (agent.oomScoreAdj) was disabled automatically because Autopilot's admission webhook rejects CAP_SYS_RESOURCE. Under memory pressure the OOM killer may terminate the agent earlier. If this cluster has a workload allowlist exemption for the agent - or is not actually an Autopilot cluster - set agent.oomScoreAdj.enabled=true to restore it.
+
+{{- end }}

--- a/charts/steadybit-agent/templates/_helpers.tpl
+++ b/charts/steadybit-agent/templates/_helpers.tpl
@@ -87,6 +87,25 @@ volume mounts for extra certificates
 {{- end -}}
 
 {{/*
+Detect GKE Autopilot clusters via the auto.gke.io API group (WorkloadAllowlist /
+AllowlistSynchronizer), which only Autopilot clusters serve. Renders "true" or "".
+*/}}
+{{- define "steadybit-agent.isGkeAutopilot" -}}
+{{- if or (.Capabilities.APIVersions.Has "auto.gke.io/v1") (.Capabilities.APIVersions.Has "auto.gke.io/v1alpha1") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the oom_score_adj feature is effectively enabled. Honors an explicit
+agent.oomScoreAdj.enabled true/false; when null, it is enabled everywhere except on GKE
+Autopilot, whose Warden admission webhook denies CAP_SYS_RESOURCE. Renders "true" or "".
+*/}}
+{{- define "steadybit-agent.oomScoreAdjEnabled" -}}
+{{- if eq .Values.agent.oomScoreAdj.enabled nil -}}
+{{- if not (include "steadybit-agent.isGkeAutopilot" .) -}}true{{- end -}}
+{{- else if .Values.agent.oomScoreAdj.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Map match labels to extension registration JSON format.
 */}}
 {{- define "matchLabelsJson" -}}

--- a/charts/steadybit-agent/templates/_helpers.tpl
+++ b/charts/steadybit-agent/templates/_helpers.tpl
@@ -98,11 +98,17 @@ AllowlistSynchronizer), which only Autopilot clusters serve. Renders "true" or "
 Whether the oom_score_adj feature is effectively enabled. Honors an explicit
 agent.oomScoreAdj.enabled true/false; when null, it is enabled everywhere except on GKE
 Autopilot, whose Warden admission webhook denies CAP_SYS_RESOURCE. Renders "true" or "".
+Fails on non-boolean values (e.g. the string "false" from quoted YAML or --set-string),
+which would otherwise be truthy and silently invert the user's intent.
 */}}
 {{- define "steadybit-agent.oomScoreAdjEnabled" -}}
-{{- if eq .Values.agent.oomScoreAdj.enabled nil -}}
+{{- $enabled := .Values.agent.oomScoreAdj.enabled -}}
+{{- if not (or (kindIs "invalid" $enabled) (kindIs "bool" $enabled)) -}}
+{{- fail (printf "agent.oomScoreAdj.enabled must be null, true or false - got the %s %q. Use an unquoted boolean (--set, not --set-string)." (kindOf $enabled) (toString $enabled)) -}}
+{{- end -}}
+{{- if kindIs "invalid" $enabled -}}
 {{- if not (include "steadybit-agent.isGkeAutopilot" .) -}}true{{- end -}}
-{{- else if .Values.agent.oomScoreAdj.enabled -}}true{{- end -}}
+{{- else if $enabled -}}true{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/steadybit-agent/templates/_podTemplate.tpl
+++ b/charts/steadybit-agent/templates/_podTemplate.tpl
@@ -240,7 +240,7 @@
             - name: STEADYBIT_AGENT_DISABLE_KUBERNETES_ACCESS
               value: "true"
             {{ end -}}
-            {{- if .Values.agent.oomScoreAdj.enabled }}
+            {{- if include "steadybit-agent.oomScoreAdjEnabled" . }}
             - name: STEADYBIT_AGENT_OOM_SCORE_ADJ
               value: {{ .Values.agent.oomScoreAdj.value | quote }}
             {{- end }}
@@ -248,7 +248,7 @@
             {{- toYaml . | nindent 12 }}
             {{- end }}
           securityContext:
-            {{- if .Values.agent.oomScoreAdj.enabled }}
+            {{- if include "steadybit-agent.oomScoreAdjEnabled" . }}
             {{- $sc := deepCopy (.Values.containerSecurityContext | default dict) }}
             {{- $_ := set $sc "allowPrivilegeEscalation" true }}
             {{- $caps := deepCopy (get $sc "capabilities" | default dict) }}

--- a/charts/steadybit-agent/templates/scc.yaml
+++ b/charts/steadybit-agent/templates/scc.yaml
@@ -9,7 +9,7 @@ runAsUser:
   uid: 10000
 seLinuxContext:
   type: MustRunAs
-{{- if .Values.agent.oomScoreAdj.enabled }}
+{{- if include "steadybit-agent.oomScoreAdjEnabled" . }}
 allowPrivilegeEscalation: true
 allowedCapabilities:
   - SYS_RESOURCE

--- a/charts/steadybit-agent/tests/__snapshot__/notes_test.yaml.snap
+++ b/charts/steadybit-agent/tests/__snapshot__/notes_test.yaml.snap
@@ -20,6 +20,28 @@ should inform about missing limits:
           kubectl logs -l app.kubernetes.io/name=RELEASE-NAME -n NAMESPACE -c steadybit-agent
 
       #### WARNING: Consider defining resource limits to prevent potential resource exhaustion. (.Values.resources.limits.memory / .Values.resources.limits.cpu)
+should not notify about oomScoreAdj when explicitly disabled on GKE Autopilot:
+  1: |
+    raw: |-
+      It may take a few moments for the agents to fully deploy. You can see what agents are running by listing resources in the NAMESPACE namespace:
+
+          kubectl get all -n NAMESPACE
+
+      You can get the logs for all of the agents with `kubectl logs`:
+
+          kubectl logs -l app.kubernetes.io/name=RELEASE-NAME -n NAMESPACE -c steadybit-agent
+should notify when oomScoreAdj is auto-disabled on GKE Autopilot:
+  1: |
+    raw: |-
+      It may take a few moments for the agents to fully deploy. You can see what agents are running by listing resources in the NAMESPACE namespace:
+
+          kubectl get all -n NAMESPACE
+
+      You can get the logs for all of the agents with `kubectl logs`:
+
+          kubectl logs -l app.kubernetes.io/name=RELEASE-NAME -n NAMESPACE -c steadybit-agent
+
+      #### NOTICE: GKE Autopilot detected (auto.gke.io API group) - the oom_score_adj protection (agent.oomScoreAdj) was disabled automatically because Autopilot's admission webhook rejects CAP_SYS_RESOURCE. Under memory pressure the OOM killer may terminate the agent earlier. If this cluster has a workload allowlist exemption for the agent - or is not actually an Autopilot cluster - set agent.oomScoreAdj.enabled=true to restore it.
 should warn about internal extension autoregistration:
   1: |
     raw: |-

--- a/charts/steadybit-agent/tests/deployment_test.yaml
+++ b/charts/steadybit-agent/tests/deployment_test.yaml
@@ -394,3 +394,56 @@ tests:
           content:
             name: STEADYBIT_AGENT_OOM_SCORE_ADJ
             value: "-500"
+
+  - it: should disable oom_score_adj automatically on GKE Autopilot
+    capabilities:
+      apiVersions:
+        - "auto.gke.io/v1"
+    set:
+      agent:
+        identifier: abcdefg
+        key: abcdefg
+        persistence:
+          provider: redis
+          redis:
+            host: 127.0.0.1
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[1].env[?(@.name=="STEADYBIT_AGENT_OOM_SCORE_ADJ")]
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities
+          value:
+            drop:
+              - ALL
+
+  - it: should still grant oom_score_adj privileges when explicitly enabled on GKE Autopilot
+    capabilities:
+      apiVersions:
+        - "auto.gke.io/v1"
+    set:
+      agent:
+        identifier: abcdefg
+        key: abcdefg
+        persistence:
+          provider: redis
+          redis:
+            host: 127.0.0.1
+        oomScoreAdj:
+          enabled: true
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: STEADYBIT_AGENT_OOM_SCORE_ADJ
+            value: "-997"
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[1].securityContext.capabilities.add
+          content: SYS_RESOURCE

--- a/charts/steadybit-agent/tests/deployment_test.yaml
+++ b/charts/steadybit-agent/tests/deployment_test.yaml
@@ -447,3 +447,19 @@ tests:
         contains:
           path: spec.template.spec.containers[1].securityContext.capabilities.add
           content: SYS_RESOURCE
+
+  - it: should reject a string value for oomScoreAdj.enabled
+    set:
+      agent:
+        identifier: abcdefg
+        key: abcdefg
+        persistence:
+          provider: redis
+          redis:
+            host: 127.0.0.1
+        oomScoreAdj:
+          enabled: "false"
+    asserts:
+      - template: deployment.yaml
+        failedTemplate:
+          errorPattern: agent.oomScoreAdj.enabled must be null, true or false

--- a/charts/steadybit-agent/tests/notes_test.yaml
+++ b/charts/steadybit-agent/tests/notes_test.yaml
@@ -60,3 +60,31 @@ tests:
           cpu: null
     asserts:
       - matchSnapshot: {}
+  - it: should notify when oomScoreAdj is auto-disabled on GKE Autopilot
+    capabilities:
+      apiVersions:
+        - "auto.gke.io/v1"
+    set:
+      global:
+        clusterName: test
+      agent:
+        key: abcdefg
+        auth:
+          provider: agent-key
+    asserts:
+      - matchSnapshot: {}
+  - it: should not notify about oomScoreAdj when explicitly disabled on GKE Autopilot
+    capabilities:
+      apiVersions:
+        - "auto.gke.io/v1"
+    set:
+      global:
+        clusterName: test
+      agent:
+        key: abcdefg
+        auth:
+          provider: agent-key
+        oomScoreAdj:
+          enabled: false
+    asserts:
+      - matchSnapshot: {}

--- a/charts/steadybit-agent/values.yaml
+++ b/charts/steadybit-agent/values.yaml
@@ -92,11 +92,14 @@ agent:
     # agent.oomScoreAdj.enabled -- Lower the agent container's oom_score_adj so the kernel OOM
     # killer terminates it last. This adds CAP_SYS_RESOURCE and allowPrivilegeEscalation=true to
     # the agent container (and to the SecurityContextConstraint on OpenShift); the container stays
-    # non-root. Enabled by default. NOTE: because it adds a capability and allows privilege
-    # escalation, the agent namespace cannot run under the `baseline`/`restricted` Pod Security
-    # Standard while this is on - disable it there. A cheaper alternative without extra privileges
-    # is to raise resources.requests.memory, which already lowers the score for Burstable pods.
-    enabled: true
+    # non-root. When null (the default) the feature is enabled everywhere except on GKE Autopilot
+    # (detected via the auto.gke.io API group), where the Warden admission webhook rejects
+    # CAP_SYS_RESOURCE. Set true/false to override the auto-detection. NOTE: because it adds a
+    # capability and allows privilege escalation, the agent namespace cannot run under the
+    # `baseline`/`restricted` Pod Security Standard while this is on - disable it there. A cheaper
+    # alternative without extra privileges is to raise resources.requests.memory, which already
+    # lowers the score for Burstable pods.
+    enabled: null
     # agent.oomScoreAdj.value -- The oom_score_adj value to apply (-1000..1000). -997 matches the
     # value Kubernetes assigns to Guaranteed QoS pods.
     value: -997

--- a/charts/steadybit-agent/values.yaml
+++ b/charts/steadybit-agent/values.yaml
@@ -94,7 +94,9 @@ agent:
     # the agent container (and to the SecurityContextConstraint on OpenShift); the container stays
     # non-root. When null (the default) the feature is enabled everywhere except on GKE Autopilot
     # (detected via the auto.gke.io API group), where the Warden admission webhook rejects
-    # CAP_SYS_RESOURCE. Set true/false to override the auto-detection. NOTE: because it adds a
+    # CAP_SYS_RESOURCE. Set true/false (unquoted booleans only - strings are rejected) to override
+    # the auto-detection. Detection needs cluster access: a bare offline `helm template` renders
+    # the non-Autopilot default unless --api-versions auto.gke.io/v1 is passed. NOTE: because it adds a
     # capability and allows privilege escalation, the agent namespace cannot run under the
     # `baseline`/`restricted` Pod Security Standard while this is on - disable it there. A cheaper
     # alternative without extra privileges is to raise resources.requests.memory, which already


### PR DESCRIPTION
## Problem

GKE Autopilot's Warden admission webhook denies the agent pod because the `agent.oomScoreAdj` feature (enabled by default) adds `CAP_SYS_RESOURCE` and `allowPrivilegeEscalation: true` to the agent container, and no WorkloadAllowlist is published for the agent:

> admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request: linux capability 'SYS_RESOURCE' on container 'steadybit-agent' not allowed

steadybit/agent#544 worked around this for a single sandbox environment by setting `agent.oomScoreAdj.enabled: false` in its env values. This PR fixes it in the chart itself so no per-environment override is needed.

## Change

- `agent.oomScoreAdj.enabled` now defaults to `null` (= auto): enabled everywhere **except** on GKE Autopilot, where it is disabled automatically. An explicit `true`/`false` still overrides the auto-detection.
- Autopilot is detected via `.Capabilities.APIVersions.Has "auto.gke.io/v1"` — the WorkloadAllowlist / AllowlistSynchronizer API group only Autopilot clusters serve — mirroring the Capabilities-based OpenShift SCC detection already in the chart.
- New helpers `steadybit-agent.isGkeAutopilot` and `steadybit-agent.oomScoreAdjEnabled` are used by the pod template (env var + securityContext) and the OpenShift SCC template.
- README documents the auto behavior; chart version bumped to 3.1.140.

Note: detection relies on Helm's cluster capabilities, so it applies on `helm install`/`upgrade` against a live cluster; a bare offline `helm template` renders the non-Autopilot default unless `--api-versions auto.gke.io/v1` is passed.

## Tests

- New unit tests: oomScoreAdj auto-disabled on Autopilot; explicit `enabled: true` still wins on Autopilot; string values for `enabled` rejected at render time; NOTES.txt notice shown on auto-disable (and suppressed when explicitly disabled).
- All 77 tests pass, 88 snapshots (pre-existing snapshots unchanged — off-Autopilot rendering is byte-identical).
- Verified with `helm template --api-versions auto.gke.io/v1`: no `SYS_RESOURCE`, no `allowPrivilegeEscalation: true`, no `STEADYBIT_AGENT_OOM_SCORE_ADJ` on the agent container.

## How it works

The chart never literally flips the value to `false` — `agent.oomScoreAdj.enabled` stays `null` and the templates ask a helper "is this effectively enabled?" at render time:

1. **The default is "undecided".** `values.yaml` ships `enabled: null`, meaning "auto" rather than a real boolean.
2. **Helm detects Autopilot by asking the cluster which APIs it serves.** On `helm install`/`upgrade`, Helm queries the Kubernetes discovery API and exposes every served API group as `.Capabilities.APIVersions`. Autopilot clusters serve a group Standard clusters don't: `auto.gke.io` (the `WorkloadAllowlist`/`AllowlistSynchronizer` CRDs — the allowlist machinery itself). The `steadybit-agent.isGkeAutopilot` helper checks exactly that.
3. **The `steadybit-agent.oomScoreAdjEnabled` helper resolves the tri-state.** It renders `"true"` or `""` (empty = falsy in Go templates), and fails rendering on non-boolean values like the string `"false"`:

   | `enabled` value | Autopilot detected? | Result |
   |---|---|---|
   | `null` (default) | no | enabled |
   | `null` (default) | **yes** | **disabled** |
   | `true` | either | enabled (override) |
   | `false` | either | disabled |

4. **Three templates consume that answer.** When it resolves to disabled, the conditional blocks simply don't render: no `STEADYBIT_AGENT_OOM_SCORE_ADJ` env var, no `SYS_RESOURCE` capability, no `allowPrivilegeEscalation: true` in the pod template, and no extra grants in the OpenShift SCC. The pod spec that reaches Autopilot's Warden webhook never requests the forbidden capability in the first place — nothing is mutated, the privileged bits are just omitted at render time. A NOTES.txt notice makes the auto-disable visible on install/upgrade.

The known blind spot: detection needs a live cluster. A bare offline `helm template` sees no `auto.gke.io` group and renders the enabled variant — such pipelines must pass `--api-versions auto.gke.io/v1` or set `agent.oomScoreAdj.enabled: false` explicitly (documented in README and values.yaml).
