### PR TITLE
ci: migrate to npm 12

### DIFF
--- a/.github/workflows/bump-chart-version.yml
+++ b/.github/workflows/bump-chart-version.yml
@@ -40,6 +40,7 @@ jobs:
 
       # this commit will effectively cause another run of the workflow which then actually performs the helm chart release
       - run: |
+          npm install -g npm@12
           npm install -g semver
           make chart-set-app-version CHART="${{ inputs.chart }}" APP_VERSION="${{ inputs.app_version }}"
           if git diff --quiet charts/${{ inputs.chart }}/Chart.yaml; then

--- a/.github/workflows/update-agent-dependencies.yml
+++ b/.github/workflows/update-agent-dependencies.yml
@@ -49,6 +49,7 @@ jobs:
             echo "No changes in dependencies" >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
+          npm install -g npm@12
           npm install -g semver
           make chart-bump-version CHART="steadybit-agent"
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
npm 12 disables dependency install scripts (plus git and remote-URL dependencies) by default — see the [npm v12.0.0 release notes](https://github.com/npm/cli/releases/tag/v12.0.0).

This workflow only uses npm to install global CLI tools; upgrade to npm 12 first so those installs run under the new script-blocking defaults.

Part of the org-wide npm 12 CI migration.
